### PR TITLE
Remove overload magic and stash when unblessing.

### DIFF
--- a/Util.xs
+++ b/Util.xs
@@ -249,8 +249,11 @@ _unbless( SV * sv, HV * seen ) {
             return sv;
 
         if ( sv_isobject( sv ) ) {
+            SvAMAGIC_off( sv );
             sv = ( SV * ) SvRV( sv );
             SvOBJECT_off( sv );
+            SvREFCNT_dec( SvSTASH( sv ) );
+            SvSTASH( sv ) = NULL;
         }
         else {
             sv = ( SV * ) SvRV( sv );

--- a/t/03bless.t
+++ b/t/03bless.t
@@ -5,8 +5,9 @@ use strict;
 use warnings;
 use Data::Structure::Util qw(unbless get_blessed has_circular_ref);
 use Data::Dumper;
+use B qw(svref_2object);
 
-use Test::More tests => 17;
+use Test::More tests => 21;
 
 ok( 1, "we loaded fine..." );
 
@@ -58,3 +59,17 @@ is( ref( $got->[0] ), 'Pie' );
 is( $a, unbless( $a ), "Have unblessed array" );
 is( $got->[0], $r );
 isnt( ref( $got->[0] ), 'Pie' );
+
+{ package overloaded; use overload q("") => sub { 'overloaded' } }
+
+my $ov = bless {}, 'overloaded';
+my $ov_stash = svref_2object($ov)->SvSTASH;
+
+is( "$ov", 'overloaded', 'Object overloaded' );
+is( $ov_stash->NAME, 'overloaded', 'Object has stash' );
+
+unbless( $ov );
+$ov_stash = svref_2object($ov)->SvSTASH;
+
+isnt( "$ov", 'overloaded', 'Not overloaded anymore' );
+is( $$ov_stash, 0, 'No more stash' );


### PR DESCRIPTION
Hello,

Ran into a bug using Perl 5.14 where an unblessed object retains its operator overloads.

Turns out that overloading was reworked in 5.18. Prior to that, it seems Perl looks at the AMAGIC flag on the object and its STASH to invoke overloads, and doesn't care about the OBJECT flag.

This patch unsets the overload flag and clears the stash association. Acme::Damn does both as well.

Thanks!